### PR TITLE
Added Carnac - Keystrokes annotation tool for screen recording

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@
 
 ### Utilities
 
+- [Carnac](http://code52.org/carnac/) - The easiest way to record keystrokes during any screen recording.
 - [LICEcap](http://www.cockos.com/licecap/) - Animated screen captures and save them directly to .GIF
 - [rimraf](https://www.npmjs.com/package/rimraf) - A deep deletion module for node. Help to delete files and folders with very long paths
 - [SDelete](https://technet.microsoft.com/en-us/sysinternals/sdelete.aspx) -  A command line utility that can securely delete a file, or clean the slack space


### PR DESCRIPTION
Carnac is a neat utility which is very helpful for capturing the keystrokes for any kind of presentation/screen recording.
[http://code52.org/carnac/](http://code52.org/carnac/) 

Signed-off-by: Vineel Kumar Reddy Kovvuri <vineel.kovvuri@gmail.com